### PR TITLE
Rate limiting support

### DIFF
--- a/app/jobs/solidus_klaviyo/subscribe_job.rb
+++ b/app/jobs/solidus_klaviyo/subscribe_job.rb
@@ -6,6 +6,8 @@ module SolidusKlaviyo
 
     def perform(list_id, email, properties = {})
       SolidusKlaviyo.subscribe_now(list_id, email, properties)
+    rescue SolidusKlaviyo::RateLimitedError => e
+      self.class.set(wait: e.retry_after).perform_later(list_id, email, properties)
     end
   end
 end

--- a/bin/rails-sandbox
+++ b/bin/rails-sandbox
@@ -6,7 +6,7 @@ app_root = 'sandbox'
 unless File.exist? "#{app_root}/bin/rails"
   warn 'Creating the sandbox app...'
   Dir.chdir "#{__dir__}/.." do
-    system "#{__dir__}/sandbox" or begin # rubocop:disable Style/AndOr
+    system "#{__dir__}/sandbox" or begin
       warn 'Automatic creation of the sandbox app failed'
       exit 1
     end

--- a/lib/solidus_klaviyo/errors.rb
+++ b/lib/solidus_klaviyo/errors.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
 module SolidusKlaviyo
-  class SubscriptionError < RuntimeError; end
+  class SubscriptionError < RuntimeError
+    attr_reader :response
+
+    def initialize(response, *args)
+      @response = response
+
+      super(response.parsed_response['detail'], *args)
+    end
+  end
+
+  class RateLimitedError < RuntimeError
+    attr_reader :response, :retry_after
+
+    def initialize(response, *args)
+      @response = response
+      @retry_after = response.headers['retry-after'].to_i.seconds
+
+      super(response.parsed_response['detail'], *args)
+    end
+  end
 end

--- a/lib/solidus_klaviyo/subscriber.rb
+++ b/lib/solidus_klaviyo/subscriber.rb
@@ -27,7 +27,16 @@ module SolidusKlaviyo
         }
       )
 
-      response.success? || raise(SubscriptionError, response.parsed_response['detail'])
+      unless response.success?
+        case response.code
+        when 429
+          raise(RateLimitedError, response)
+        else
+          raise(SubscriptionError, response)
+        end
+      end
+
+      response
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/subscriber-rate-limited.yml
+++ b/spec/fixtures/vcr_cassettes/subscriber-rate-limited.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://a.klaviyo.com/api/v2/list/dummyListId/subscribe
+    body:
+      encoding: UTF-8
+      string: '{"api_key":"secret123","profiles":[{"email":"jdoe@example.com"}]}'
+    headers:
+      Content-Type:
+        - application/json
+      Accept:
+        - application/json
+      Accept-Encoding:
+        - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+        - Ruby
+  response:
+    status:
+      code: 429
+      message: Too Many Requests
+    headers:
+      Allow:
+        - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Type:
+        - application/json
+      Date:
+        - Wed, 22 Jul 2020 13:40:48 GMT
+      Server:
+        - nginx
+      Vary:
+        - Accept-Encoding
+        - Cookie
+      X-Upstream:
+        - Sync-Api
+        - Sync-Api
+      Content-Length:
+        - '22'
+      Connection:
+        - keep-alive
+      retry-after:
+        60
+    body:
+      encoding: ASCII-8BIT
+      string: '{"detail":""}'
+  recorded_at: Fri, 13 Nov 2020 11:01:00 GMT
+recorded_with: VCR 6.0.0

--- a/spec/solidus_klaviyo/subscriber_spec.rb
+++ b/spec/solidus_klaviyo/subscriber_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe SolidusKlaviyo::Subscriber do
           VCR.use_cassette('subscriber') do
             subscriber.subscribe(list_id, email)
           end
-
         }.to raise_error(SolidusKlaviyo::SubscriptionError)
       end
     end

--- a/spec/solidus_klaviyo/subscriber_spec.rb
+++ b/spec/solidus_klaviyo/subscriber_spec.rb
@@ -28,17 +28,32 @@ RSpec.describe SolidusKlaviyo::Subscriber do
       end
     end
 
+    context 'when the request is rate-limited' do
+      it 'raises a RateLimitedError' do
+        subscriber = described_class.new(api_key: 'test_key')
+        list_id = 'dummyListId'
+        email = 'jdoe@example.com'
+
+        expect {
+          VCR.use_cassette('subscriber-rate-limited') do
+            subscriber.subscribe(list_id, email)
+          end
+        }.to raise_error(SolidusKlaviyo::RateLimitedError)
+      end
+    end
+
     context 'when the request is malformed' do
       it 'raises a SubscriptionError' do
         subscriber = described_class.new(api_key: 'test_key')
         list_id = 'wrongListId'
         email = 'jdoe@example.com'
 
-        VCR.use_cassette('subscriber') do
-          expect {
+        expect {
+          VCR.use_cassette('subscriber') do
             subscriber.subscribe(list_id, email)
-          }.to raise_error(SolidusKlaviyo::SubscriptionError)
-        end
+          end
+
+        }.to raise_error(SolidusKlaviyo::SubscriptionError)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ require 'solidus_dev_support/rspec/feature_helper'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
+Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].sort.each { |f| require f }
 
 # Requires factories defined in lib/solidus_klaviyo/factories.rb
 require 'solidus_klaviyo/factories'


### PR DESCRIPTION
Handles Klaviyo rate limiting by re-trying failed jobs with the timeout specified by Klaviyo.