### PR TITLE
Add update action to subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ end
 Now, all users will be subscribed to the configured list automatically when their account is
 created.
 
+### Updating users on your lists
+
+Updating an existing user on a list is just as easy as adding them.
+
+```ruby
+SolidusKlaviyo.update_now('YOUR_LIST_ID', 'jdoe@example.com', custom_property: 'value') 
+```
+
+Just like with subscribing, we recommend using the built-in background job to update users,
+in order to avoid blocking your web workers and slowing down the customer:
+
+```ruby
+SolidusKlaviyo.update_later('YOUR_LIST_ID', 'jdoe@example.com', custom_property: 'value')
+```
+
 ## Development
 
 ### Testing the extension

--- a/app/jobs/solidus_klaviyo/update_job.rb
+++ b/app/jobs/solidus_klaviyo/update_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SolidusKlaviyo
+  class UpdateJob < ApplicationJob
+    queue_as :default
+
+    def perform(list_id, email, properties = {})
+      SolidusKlaviyo.update_now(list_id, email, properties)
+    rescue SolidusKlaviyo::RateLimitedError => e
+      self.class.set(wait: e.retry_after).perform_later(list_id, email, properties)
+    end
+  end
+end

--- a/lib/solidus_klaviyo.rb
+++ b/lib/solidus_klaviyo.rb
@@ -31,6 +31,14 @@ module SolidusKlaviyo
       SolidusKlaviyo::SubscribeJob.perform_later(list_id, email, properties)
     end
 
+    def update_now(list_id, email, properties = {})
+      subscriber.update(list_id, email, properties)
+    end
+
+    def update_later(list_id, email, properties = {})
+      SolidusKlaviyo::UpdateJob.perform_later(list_id, email, properties)
+    end
+
     private
 
     def subscriber

--- a/lib/solidus_klaviyo/subscriber.rb
+++ b/lib/solidus_klaviyo/subscriber.rb
@@ -15,8 +15,18 @@ module SolidusKlaviyo
     end
 
     def subscribe(list_id, email, properties = {})
+      request(list_id, email, properties, "subscribe")
+    end
+
+    def update(list_id, email, properties = {})
+      request(list_id, email, properties, "members")
+    end
+
+    private
+
+    def request(list_id, email, properties, object)
       response = HTTParty.post(
-        "https://a.klaviyo.com/api/v2/list/#{list_id}/subscribe",
+        "https://a.klaviyo.com/api/v2/list/#{list_id}/#{object}",
         body: {
           api_key: api_key,
           profiles: [properties.merge('email' => email)],

--- a/spec/fixtures/vcr_cassettes/update-rate-limited.yml
+++ b/spec/fixtures/vcr_cassettes/update-rate-limited.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://a.klaviyo.com/api/v2/list/dummyListId/members
+    body:
+      encoding: UTF-8
+      string: '{"api_key":"secret123","profiles":[{"email":"jdoe@example.com"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 429
+      message: Too Many Requests
+    headers:
+      Allow:
+        - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Type:
+        - application/json
+      Date:
+        - Wed, 22 Jul 2020 13:40:48 GMT
+      Server:
+        - nginx
+      Vary:
+        - Accept-Encoding
+        - Cookie
+      X-Upstream:
+        - Sync-Api
+        - Sync-Api
+      Content-Length:
+        - '22'
+      Connection:
+        - keep-alive
+      retry-after:
+        60
+    body:
+      encoding: ASCII-8BIT
+      string: '{"detail":""}'
+  recorded_at: Thu, 24 Dec 2020 22:39:22 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/update.yml
+++ b/spec/fixtures/vcr_cassettes/update.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://a.klaviyo.com/api/v2/list/dummyListId/members
+    body:
+      encoding: UTF-8
+      string: '{"api_key":"secret123","profiles":[{"email":"jdoe@example.com"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 24 Dec 2020 22:37:33 GMT
+      Server:
+      - nginx
+      Vary:
+      - Cookie
+      Content-Length:
+      - '76'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"api_key":"secret123","profiles":[{"email":"jdoe@example.com"}]}'
+  recorded_at: Thu, 24 Dec 2020 22:37:33 GMT
+- request:
+    method: post
+    uri: https://a.klaviyo.com/api/v2/list/wrongListId/members
+    body:
+      encoding: UTF-8
+      string: '{"api_key":"secret123","profiles":[{"email":"jdoe@example.com"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 24 Dec 2020 22:38:12 GMT
+      Server:
+      - nginx
+      Vary:
+      - Cookie
+      Content-Length:
+      - '40'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"detail":"List wrongListId does not exist."}'
+  recorded_at: Thu, 24 Dec 2020 22:38:12 GMT
+recorded_with: VCR 6.0.0

--- a/spec/jobs/solidus_klaviyo/update_job_spec.rb
+++ b/spec/jobs/solidus_klaviyo/update_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe SolidusKlaviyo::UpdateJob do
+  include ActiveSupport::Testing::TimeHelpers
+
+  context 'when Klaviyo is not rate-limited' do
+    it 'updates the given email on the given list' do
+      solidus_klaviyo = class_spy(SolidusKlaviyo)
+      stub_const('SolidusKlaviyo', solidus_klaviyo)
+
+      described_class.perform_now('dummyListId', 'jdoe@example.com', first_name: 'John')
+
+      expect(solidus_klaviyo).to have_received(:update_now).with(
+        'dummyListId',
+        'jdoe@example.com',
+        first_name: 'John',
+      )
+    end
+  end
+
+  context 'when Klaviyo is rate-limited' do
+    it 'reschedules the job for later' do
+      freeze_time do
+        allow(SolidusKlaviyo).to receive(:update_now)
+          .and_raise(SolidusKlaviyo::RateLimitedError.new(OpenStruct.new(
+            headers: { 'retry-after' => 60 },
+            parsed_response: { 'detail' => 'error message' },
+          )))
+
+        described_class.perform_now('dummyListId', 'jdoe@example.com', first_name: 'John')
+
+        expect(described_class).to have_been_enqueued.with(
+          'dummyListId',
+          'jdoe@example.com',
+          first_name: 'John',
+        ).at(60.seconds.from_now)
+      end
+    end
+  end
+end

--- a/spec/solidus_klaviyo_spec.rb
+++ b/spec/solidus_klaviyo_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe SolidusKlaviyo do
     it 'subscribes the profile to the given list' do
       allow(described_class.configuration).to receive(:api_key).and_return('test_key')
       subscriber = instance_spy(SolidusKlaviyo::Subscriber)
-      allow(SolidusKlaviyo::Subscriber).to receive(:new)
-        .with(api_key: 'test_key')
-        .and_return(subscriber)
+      allow(described_class).to receive(:subscriber) { subscriber }
 
       described_class.subscribe_now('fakeList', 'jdoe@example.com', property: 'value')
 
@@ -24,6 +22,34 @@ RSpec.describe SolidusKlaviyo do
       described_class.subscribe_later('fakeList', 'jdoe@example.com', property: 'value')
 
       expect(SolidusKlaviyo::SubscribeJob).to have_been_enqueued.with(
+        'fakeList',
+        'jdoe@example.com',
+        property: 'value',
+      )
+    end
+  end
+
+  describe '.update_now' do
+    it 'updates the profile on the given list' do
+      allow(described_class.configuration).to receive(:api_key).and_return('test_key')
+      subscriber = instance_spy(SolidusKlaviyo::Subscriber)
+      allow(described_class).to receive(:subscriber) { subscriber }
+
+      described_class.update_now('fakeList', 'jdoe@example.com', property: 'value')
+
+      expect(subscriber).to have_received(:update).with(
+        'fakeList',
+        'jdoe@example.com',
+        property: 'value',
+      )
+    end
+  end
+
+  describe '.update_later' do
+    it 'enqueues a UpdateJob' do
+      described_class.update_later('fakeList', 'jdoe@example.com', property: 'value')
+
+      expect(SolidusKlaviyo::UpdateJob).to have_been_enqueued.with(
         'fakeList',
         'jdoe@example.com',
         property: 'value',


### PR DESCRIPTION
Updating, rather than subscribing, is useful for when the subscriber
changes their information and you want to reflect that in Klaviyo.