### PR TITLE
Add bulk update action to subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ in order to avoid blocking your web workers and slowing down the customer:
 SolidusKlaviyo.update_later('YOUR_LIST_ID', 'jdoe@example.com', custom_property: 'value')
 ```
 
+Updating in bulk is also possible using the `bulk_update_now` and `bulk_update_later` methods.
+For bulk updates, you'll want to provide the emails and custom properties in a single object,
+like so:
+
+```ruby
+SolidusKlaviyo.bulk_update_later('YOUR_LIST_ID', [{email: 'jdoe@example.com', custom_property: 'value'}])
+```
+
 ## Development
 
 ### Testing the extension

--- a/app/jobs/solidus_klaviyo/bulk_update_job.rb
+++ b/app/jobs/solidus_klaviyo/bulk_update_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SolidusKlaviyo
+  class BulkUpdateJob < ApplicationJob
+    queue_as :default
+
+    def perform(list_id, profiles)
+      SolidusKlaviyo.bulk_update_now(list_id, profiles)
+    rescue SolidusKlaviyo::RateLimitedError => e
+      self.class.set(wait: e.retry_after).perform_later(list_id, profiles)
+    end
+  end
+end

--- a/lib/solidus_klaviyo.rb
+++ b/lib/solidus_klaviyo.rb
@@ -39,6 +39,14 @@ module SolidusKlaviyo
       SolidusKlaviyo::UpdateJob.perform_later(list_id, email, properties)
     end
 
+    def bulk_update_now(list_id, profiles)
+      subscriber.bulk_update(list_id, profiles)
+    end
+
+    def bulk_update_later(list_id, profiles)
+      SolidusKlaviyo::BulkUpdateJob.perform_later(list_id, profiles)
+    end
+
     private
 
     def subscriber

--- a/lib/solidus_klaviyo/subscriber.rb
+++ b/lib/solidus_klaviyo/subscriber.rb
@@ -15,21 +15,23 @@ module SolidusKlaviyo
     end
 
     def subscribe(list_id, email, properties = {})
-      request(list_id, email, properties, "subscribe")
+      profiles = [properties.merge('email' => email)]
+      request(list_id, profiles, "subscribe")
     end
 
     def update(list_id, email, properties = {})
-      request(list_id, email, properties, "members")
+      profiles = [properties.merge('email' => email)]
+      request(list_id, profiles, "members")
     end
 
     private
 
-    def request(list_id, email, properties, object)
+    def request(list_id, profiles, object)
       response = HTTParty.post(
         "https://a.klaviyo.com/api/v2/list/#{list_id}/#{object}",
         body: {
           api_key: api_key,
-          profiles: [properties.merge('email' => email)],
+          profiles: profiles,
         }.to_json,
         headers: {
           'Content-Type' => 'application/json',

--- a/lib/solidus_klaviyo/subscriber.rb
+++ b/lib/solidus_klaviyo/subscriber.rb
@@ -24,6 +24,10 @@ module SolidusKlaviyo
       request(list_id, profiles, "members")
     end
 
+    def bulk_update(list_id, profiles)
+      request(list_id, profiles, "members")
+    end
+
     private
 
     def request(list_id, profiles, object)

--- a/spec/jobs/solidus_klaviyo/bulk_update_job_spec.rb
+++ b/spec/jobs/solidus_klaviyo/bulk_update_job_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe SolidusKlaviyo::BulkUpdateJob do
+  include ActiveSupport::Testing::TimeHelpers
+
+  context 'when Klaviyo is not rate-limited' do
+    it 'updates the profile on the given list' do
+      solidus_klaviyo = class_spy(SolidusKlaviyo)
+      stub_const('SolidusKlaviyo', solidus_klaviyo)
+
+      described_class.perform_now('dummyListId', {email: 'jdoe@example.com', first_name: 'John'})
+
+      expect(solidus_klaviyo).to have_received(:bulk_update_now).with(
+        'dummyListId',
+        {email: 'jdoe@example.com', first_name: 'John'},
+      )
+    end
+  end
+
+  context 'when Klaviyo is rate-limited' do
+    it 'reschedules the job for later' do
+      freeze_time do
+        allow(SolidusKlaviyo).to receive(:bulk_update_now)
+          .and_raise(SolidusKlaviyo::RateLimitedError.new(OpenStruct.new(
+            headers: { 'retry-after' => 60 },
+            parsed_response: { 'detail' => 'error message' },
+          )))
+
+        described_class.perform_now('dummyListId', {email: 'jdoe@example.com', first_name: 'John'})
+
+        expect(described_class).to have_been_enqueued.with(
+          'dummyListId',
+          {email: 'jdoe@example.com', first_name: 'John'},
+        ).at(60.seconds.from_now)
+      end
+    end
+  end
+end

--- a/spec/solidus_klaviyo/subscriber_spec.rb
+++ b/spec/solidus_klaviyo/subscriber_spec.rb
@@ -102,4 +102,50 @@ RSpec.describe SolidusKlaviyo::Subscriber do
       end
     end
   end
+
+  describe '#bulk_update' do
+    context 'when the request is well-formed' do
+      it 'updates the profile on the configured list' do
+        subscriber = described_class.new(api_key: 'test_key')
+        list_id = 'dummyListId'
+        profile = {email: 'jdoe@example.com'}
+
+        VCR.use_cassette('update') do
+          subscriber.bulk_update(list_id, profile)
+        end
+
+        expect(
+          a_request(:post, "https://a.klaviyo.com/api/v2/list/#{list_id}/members")
+        ).to have_been_made
+      end
+    end
+
+    context 'when the request is rate-limited' do
+      it 'raises a RateLimitedError' do
+        subscriber = described_class.new(api_key: 'test_key')
+        list_id = 'dummyListId'
+        profile = {email: 'jdoe@example.com'}
+
+        expect {
+          VCR.use_cassette('update-rate-limited') do
+            subscriber.bulk_update(list_id, profile)
+          end
+        }.to raise_error(SolidusKlaviyo::RateLimitedError)
+      end
+    end
+
+    context 'when the request is malformed' do
+      it 'raises a SubscriptionError' do
+        subscriber = described_class.new(api_key: 'test_key')
+        list_id = 'wrongListId'
+        profile = {email: 'jdoe@example.com'}
+
+        expect {
+          VCR.use_cassette('update') do
+            subscriber.bulk_update(list_id, profile)
+          end
+        }.to raise_error(SolidusKlaviyo::SubscriptionError)
+      end
+    end
+  end
 end

--- a/spec/solidus_klaviyo_spec.rb
+++ b/spec/solidus_klaviyo_spec.rb
@@ -56,4 +56,30 @@ RSpec.describe SolidusKlaviyo do
       )
     end
   end
+
+  describe '.bulk_update_now' do
+    it 'updates the profile on the given list' do
+      allow(described_class.configuration).to receive(:api_key).and_return('test_key')
+      subscriber = instance_spy(SolidusKlaviyo::Subscriber)
+      allow(described_class).to receive(:subscriber) { subscriber }
+
+      described_class.bulk_update_now('fakeList', {email: 'jdoe@example.com', first_name: 'John'})
+
+      expect(subscriber).to have_received(:bulk_update).with(
+        'fakeList',
+        {email: 'jdoe@example.com', first_name: 'John'},
+      )
+    end
+  end
+
+  describe '.bulk_update_later' do
+    it 'enqueues a UpdateJob' do
+      described_class.bulk_update_later('fakeList', {email: 'jdoe@example.com', first_name: 'John'})
+
+      expect(SolidusKlaviyo::BulkUpdateJob).to have_been_enqueued.with(
+        'fakeList',
+        {email: 'jdoe@example.com', first_name: 'John'},
+      )
+    end
+  end
 end


### PR DESCRIPTION
Sometimes it's useful to update your subscribers profiles in bulk,
for example if you want to do a nightly sync with Klaviyo. This gives
you that ability!